### PR TITLE
add initial rotation

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -1,0 +1,6 @@
+{
+  "version": "1.0",
+  "components": [ 
+    "Microsoft.VisualStudio.Workload.ManagedGame"
+  ]
+} 

--- a/Assets/LookAtTarget.cs
+++ b/Assets/LookAtTarget.cs
@@ -24,9 +24,10 @@ public class LookAtTarget : MonoBehaviour
 
         float time = 0;
 
+        Quaternion initialRotation = transform.rotation;
         while (time < 1)
         {
-            transform.rotation = Quaternion.Slerp(transform.rotation, lookRotation, time);
+            transform.rotation = Quaternion.Slerp(initialRotation, lookRotation, time);
 
             time += Time.deltaTime * Speed;
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Smooth Look At
 The below video is the tutorial that **ENDS** where this project is. 
 
-[![Youtube Tutorial](./Video%20Screenshot.png)](https://www.youtube.com/watch?v=2XEiHf1N_EY&ref=github)
-
 In this project we have:
 1. A simple scene with 2 variants of how to "look at" a target.
 2. LookAtTarget script - smoothly rotates an object to look at the specified trasnform
 3. AlwaysLookAtTarget - the "simple" way to make a transform look at another target, updating in a single frame
+
+[![Youtube Tutorial](./Video%20Screenshot.png)](https://www.youtube.com/watch?v=2XEiHf1N_EY&ref=github)
 
 ## Requirements
 * Requires Unity 2019.4 LTS or higher. Lower probably also works but is untested.


### PR DESCRIPTION
As mentioned in a comment, initial rotation was not stored so the Quaternion.Slerp was inaccurate.

Small update to format of the readme